### PR TITLE
gear doctor 페이지에서 이미지 오류 수정

### DIFF
--- a/gearbear/android/app/build.gradle.kts
+++ b/gearbear/android/app/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 android {
     namespace = "com.example.gearbear"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
@@ -27,8 +27,8 @@ android {
         applicationId = "com.example.gearbear"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = flutter.minSdkVersion
-        targetSdk = flutter.targetSdkVersion
+        minSdk = 23
+        targetSdk = 34
         versionCode = flutter.versionCode
         versionName = flutter.versionName
     }

--- a/gearbear/android/app/src/main/AndroidManifest.xml
+++ b/gearbear/android/app/src/main/AndroidManifest.xml
@@ -38,6 +38,7 @@
             android:value="2" />
     </application>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.INTERNET" />
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and
          https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.

--- a/gearbear/lib/gearList.dart
+++ b/gearbear/lib/gearList.dart
@@ -192,30 +192,30 @@ class _GearListPageState extends State<GearListPage> {
                                 horizontal: 16,
                               ),
                               leading: SizedBox(
-                            width: 56,
-                            height: 56,
-                            child: gear.imgUrl.isNotEmpty
-                                ? ClipRRect(
-                                    borderRadius: BorderRadius.circular(12),
-                                    child: Image.network(
-                                      gear.imgUrl,
-                                      width: 56,
-                                      height: 56,
-                                      fit: BoxFit.cover,
-                                      errorBuilder: (context, error, stackTrace) => 
-                                        Container(
-                                          color: Colors.grey[200],
-                                          child: const Icon(Icons.image_not_supported, size: 32, color: Colors.grey),
+                                width: 56,
+                                height: 56,
+                                child: gear.imgUrl.isNotEmpty
+                                    ? ClipRRect(
+                                        borderRadius: BorderRadius.circular(12),
+                                        child: Image.network(
+                                          gear.imgUrl,
+                                          width: 56,
+                                          height: 56,
+                                          fit: BoxFit.cover,
+                                          errorBuilder: (context, error, stackTrace) => 
+                                            Container(
+                                              color: Colors.grey[200],
+                                              child: const Icon(Icons.image_not_supported, size: 32, color: Colors.grey),
+                                            ),
                                         ),
-                                    ),
-                                  )
-                                : Container(
-                                    decoration: BoxDecoration(
-                                      color: Colors.grey[200],
-                                      borderRadius: BorderRadius.circular(12),
-                                    ),
-                                    child: const Icon(Icons.image_not_supported, size: 32, color: Colors.grey),
-                                  ),
+                                      )
+                                    : Container(
+                                        decoration: BoxDecoration(
+                                          color: Colors.grey[200],
+                                          borderRadius: BorderRadius.circular(12),
+                                        ),
+                                        child: const Icon(Icons.image_not_supported, size: 32, color: Colors.grey),
+                                      ),
                               ),
                               title: Text(
                                 gear.gearName,

--- a/gearbear/pubspec.yaml
+++ b/gearbear/pubspec.yaml
@@ -78,6 +78,7 @@ flutter:
   assets:
     - assets/images/
     - assets/mapData/Camp_Map.csv
+    - .env
   #   - images/a_dot_ham.jpeg
 
   # An image asset can refer to one or more resolution-specific "variants", see


### PR DESCRIPTION
- 기존에 Gear Doctor Page에서 gear name으로 이미지 검색에 대한 로직을 구현함
- 그러나, 이렇게 찾은 이미지가 실제로는 손상된 이미지이거나 CORS 및 호환성 문제로 Flutter에서 열 수 없을 수 있었음
- 이를 해결하기 위해 각각의 이미지를 직접 실행해보고 가능한 경우에 한해서만 이미지를 저장하도록 설정함